### PR TITLE
Task 2: Utils split/reverse/filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+on: [pull_request]
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/ozonva/ova-purchase-api
 
 go 1.16
+
+require github.com/stretchr/testify v1.7.0
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ozonva/ova-purchase-api
+
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,11 +17,14 @@ func Split(input []int, size int) ([][]int, error) {
 		return nil, errors.New("size must be positive")
 	}
 	batches := int(math.Ceil(float64(len(input)) / float64(size)))
-	result := make([][]int, 0)
+	result := make([][]int, 0, batches)
 	for i := 0; i < batches; i++ {
 		left := i * size
 		right := min(len(input), left+size)
-		result = append(result, input[left:right])
+		source := input[left:right]
+		buf := make([]int, len(source))
+		copy(buf, source)
+		result = append(result, buf)
 	}
 	return result, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"errors"
+	"math"
+)
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func Split(input []int, size int) ([][]int, error) {
+	if size <= 0 {
+		return nil, errors.New("size must be positive")
+	}
+	batches := int(math.Ceil(float64(len(input)) / float64(size)))
+	result := make([][]int, 0)
+	for i := 0; i < batches; i++ {
+		left := i * size
+		right := min(len(input), left+size)
+		result = append(result, input[left:right])
+	}
+	return result, nil
+}
+
+func Reverse(input map[string]string) (map[string]string, error) {
+	result := make(map[string]string)
+	for k, v := range input {
+		if _, ok := result[v]; ok {
+			return nil, errors.New("key already exists")
+		}
+		result[v] = k
+	}
+	return result, nil
+}
+
+func Filter(input []int, exclude []int) []int {
+	if len(exclude) == 0 {
+		return input
+	}
+	set := make(map[int]bool)
+	for _, value := range exclude {
+		set[value] = true
+	}
+	result := make([]int, 0)
+	for _, value := range input {
+		if _, ok := set[value]; !ok {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"reflect"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -11,13 +11,9 @@ func TestSplitNotFullSuccess(t *testing.T) {
 
 	actual, err := Split(items, 3)
 
-	if err != nil {
-		t.Fatalf("Error %s not expected", err)
-	}
+	require.NoError(t, err)
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
-	}
+	require.Equal(t, actual, expected)
 }
 
 func TestSplitFullSuccess(t *testing.T) {
@@ -26,23 +22,19 @@ func TestSplitFullSuccess(t *testing.T) {
 
 	actual, err := Split(items, 2)
 
-	if err != nil {
-		t.Fatalf("Error %s not expected", err)
-	}
+	require.NoError(t, err)
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
-	}
+	require.Equal(t, actual, expected)
 }
 
 func TestSplitFailure(t *testing.T) {
 	items := []int{1, 2, 3, 4}
 
-	_, err := Split(items, 0)
+	val, err := Split(items, 0)
 
-	if err == nil {
-		t.Fatal("Error expected")
-	}
+	require.Nil(t, val)
+
+	require.Error(t, err)
 }
 
 func TestSplitEmpty(t *testing.T) {
@@ -50,13 +42,9 @@ func TestSplitEmpty(t *testing.T) {
 
 	actual, err := Split(items, 5)
 
-	if err != nil {
-		t.Fatalf("Error %s not expected", err)
-	}
+	require.NoError(t, err)
 
-	if len(actual) != 0 {
-		t.Fatal("Expected empty slice")
-	}
+	require.Len(t, actual, 0)
 }
 
 func TestFilterSuccess(t *testing.T) {
@@ -65,9 +53,7 @@ func TestFilterSuccess(t *testing.T) {
 
 	actual := Filter(items, []int{3, 7})
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
-	}
+	require.Equal(t, actual, expected)
 }
 
 func TestFilterWithoutExcludeSuccess(t *testing.T) {
@@ -76,9 +62,7 @@ func TestFilterWithoutExcludeSuccess(t *testing.T) {
 
 	actual := Filter(items, nil)
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
-	}
+	require.Equal(t, actual, expected)
 }
 
 func TestReverseSuccess(t *testing.T) {
@@ -86,22 +70,16 @@ func TestReverseSuccess(t *testing.T) {
 	expected := map[string]string{"second": "first", "2": "1", "test-3": "test-1"}
 
 	actual, err := Reverse(items)
-
-	if err != nil {
-		t.Fatalf("Error %s not expected", err)
-	}
-
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
-	}
+	require.NoError(t, err)
+	require.Equal(t, actual, expected)
 }
 
 func TestReverseFailure(t *testing.T) {
 	items := map[string]string{"first": "second", "third": "second"}
 
-	_, err := Reverse(items)
+	val, err := Reverse(items)
 
-	if err == nil {
-		t.Fatal("Error expected")
-	}
+	require.Nil(t, val)
+
+	require.Error(t, err)
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitNotFullSuccess(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	expected := [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10}}
+
+	actual, err := Split(items, 3)
+
+	if err != nil {
+		t.Fatalf("Error %s not expected", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
+	}
+}
+
+func TestSplitFullSuccess(t *testing.T) {
+	items := []int{1, 2, 3, 4}
+	expected := [][]int{{1, 2}, {3, 4}}
+
+	actual, err := Split(items, 2)
+
+	if err != nil {
+		t.Fatalf("Error %s not expected", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
+	}
+}
+
+func TestSplitFailure(t *testing.T) {
+	items := []int{1, 2, 3, 4}
+
+	_, err := Split(items, 0)
+
+	if err == nil {
+		t.Fatal("Error expected")
+	}
+}
+
+func TestSplitEmpty(t *testing.T) {
+	items := []int{}
+
+	actual, err := Split(items, 5)
+
+	if err != nil {
+		t.Fatalf("Error %s not expected", err)
+	}
+
+	if len(actual) != 0 {
+		t.Fatal("Expected empty slice")
+	}
+}
+
+func TestFilterSuccess(t *testing.T) {
+	items := []int{1, 3, 5, 7, 8}
+	expected := []int{1, 5, 8}
+
+	actual := Filter(items, []int{3, 7})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
+	}
+}
+
+func TestFilterWithoutExcludeSuccess(t *testing.T) {
+	items := []int{1, 2, 4}
+	expected := []int{1, 2, 4}
+
+	actual := Filter(items, nil)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
+	}
+}
+
+func TestReverseSuccess(t *testing.T) {
+	items := map[string]string{"first": "second", "1": "2", "test-1": "test-3"}
+	expected := map[string]string{"second": "first", "2": "1", "test-3": "test-1"}
+
+	actual, err := Reverse(items)
+
+	if err != nil {
+		t.Fatalf("Error %s not expected", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nActual:%v\nExpect:%v", actual, expected)
+	}
+}
+
+func TestReverseFailure(t *testing.T) {
+	items := map[string]string{"first": "second", "third": "second"}
+
+	_, err := Reverse(items)
+
+	if err == nil {
+		t.Fatal("Error expected")
+	}
+}


### PR DESCRIPTION
В пакете internal/utils вашего репозитория нужно реализовать экспортируемые функции для

- Разделение слайса на батчи - исходный слайс конвертировать в слайс слайсов - чанки одинкового размера (кроме последнего)
- Обратный ключ - происходит конвертация отображения (“ключ-значение“) в отображение (“значение-ключ“)
- Фильтрация по захордкоженному списку - нужно отфильтровать входной слайс по критерию отсутствия элемента в захардкоженном списке

В качестве типов сейчас будем использовать встроенные типы: целые числа или строковые